### PR TITLE
Fixed bug with encodings on Windows machines

### DIFF
--- a/homoglyphs/core.py
+++ b/homoglyphs/core.py
@@ -93,7 +93,7 @@ class Languages:
         :return: set of chars in alphabet by languages list
         :rtype: set
         """
-        with open(cls.fpath) as f:
+        with open(cls.fpath, encoding='utf-8') as f:
             data = json.load(f)
         alphabet = set()
         for lang in languages:


### PR DESCRIPTION
On Windows machines with platform encoding "CP1251" fixed next bug: UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 286: character maps to <undefined>