### PR TITLE
Math homoglyphs

### DIFF
--- a/homoglyphs/categories.json
+++ b/homoglyphs/categories.json
@@ -80,6 +80,7 @@
     "MANICHAEAN",
     "MARCHEN",
     "MASARAM_GONDI",
+    "MATH",
     "MEDEFAIDRIN",
     "MEETEI_MAYEK",
     "MENDE_KIKAKUI",
@@ -9582,207 +9583,207 @@
     [
       119808,
       119892,
-      "COMMON"
+      "MATH"
     ],
     [
       119894,
       119964,
-      "COMMON"
+      "MATH"
     ],
     [
       119966,
       119967,
-      "COMMON"
+      "MATH"
     ],
     [
       119970,
       119970,
-      "COMMON"
+      "MATH"
     ],
     [
       119973,
       119974,
-      "COMMON"
+      "MATH"
     ],
     [
       119977,
       119980,
-      "COMMON"
+      "MATH"
     ],
     [
       119982,
       119993,
-      "COMMON"
+      "MATH"
     ],
     [
       119995,
       119995,
-      "COMMON"
+      "MATH"
     ],
     [
       119997,
       120003,
-      "COMMON"
+      "MATH"
     ],
     [
       120005,
       120069,
-      "COMMON"
+      "MATH"
     ],
     [
       120071,
       120074,
-      "COMMON"
+      "MATH"
     ],
     [
       120077,
       120084,
-      "COMMON"
+      "MATH"
     ],
     [
       120086,
       120092,
-      "COMMON"
+      "MATH"
     ],
     [
       120094,
       120121,
-      "COMMON"
+      "MATH"
     ],
     [
       120123,
       120126,
-      "COMMON"
+      "MATH"
     ],
     [
       120128,
       120132,
-      "COMMON"
+      "MATH"
     ],
     [
       120134,
       120134,
-      "COMMON"
+      "MATH"
     ],
     [
       120138,
       120144,
-      "COMMON"
+      "MATH"
     ],
     [
       120146,
       120485,
-      "COMMON"
+      "MATH"
     ],
     [
       120488,
       120512,
-      "COMMON"
+      "MATH"
     ],
     [
       120513,
       120513,
-      "COMMON"
+      "MATH"
     ],
     [
       120514,
       120538,
-      "COMMON"
+      "MATH"
     ],
     [
       120539,
       120539,
-      "COMMON"
+      "MATH"
     ],
     [
       120540,
       120570,
-      "COMMON"
+      "MATH"
     ],
     [
       120571,
       120571,
-      "COMMON"
+      "MATH"
     ],
     [
       120572,
       120596,
-      "COMMON"
+      "MATH"
     ],
     [
       120597,
       120597,
-      "COMMON"
+      "MATH"
     ],
     [
       120598,
       120628,
-      "COMMON"
+      "MATH"
     ],
     [
       120629,
       120629,
-      "COMMON"
+      "MATH"
     ],
     [
       120630,
       120654,
-      "COMMON"
+      "MATH"
     ],
     [
       120655,
       120655,
-      "COMMON"
+      "MATH"
     ],
     [
       120656,
       120686,
-      "COMMON"
+      "MATH"
     ],
     [
       120687,
       120687,
-      "COMMON"
+      "MATH"
     ],
     [
       120688,
       120712,
-      "COMMON"
+      "MATH"
     ],
     [
       120713,
       120713,
-      "COMMON"
+      "MATH"
     ],
     [
       120714,
       120744,
-      "COMMON"
+      "MATH"
     ],
     [
       120745,
       120745,
-      "COMMON"
+      "MATH"
     ],
     [
       120746,
       120770,
-      "COMMON"
+      "MATH"
     ],
     [
       120771,
       120771,
-      "COMMON"
+      "MATH"
     ],
     [
       120772,
       120779,
-      "COMMON"
+      "MATH"
     ],
     [
       120782,
       120831,
-      "COMMON"
+      "MATH"
     ],
     [
       120832,

--- a/homoglyphs/core.py
+++ b/homoglyphs/core.py
@@ -63,7 +63,7 @@ class Categories:
 
         # try detect category by unicodedata
         try:
-            category = unicodedata.name(char).split()[0]
+            category = unicodedata.name(char, default='UNKNOWN').split()[0]
         except TypeError:
             # In Python2 unicodedata.name raise error for non-unicode chars
             pass


### PR DESCRIPTION
This PR renames several ranges listed as "COMMON" to "MATH", based on the information found in https://unicode.org/charts/PDF/U1D400.pdf

Also makes a minor change to avoid a ValueError when trying to get the category for characters that aren't in the known set, such as `U+E01F0`, which seems to be included in some implementations but is shown as an invalid Unicode character when I searched for it.